### PR TITLE
uhttp cleanup

### DIFF
--- a/pkg/connector/client/confluence.go
+++ b/pkg/connector/client/confluence.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -383,13 +384,7 @@ func (c *ConfluenceClient) UpdateSpacePermissions(ctx context.Context, operation
 		return nil, err
 	}
 
-	requestBody, err := json.Marshal(bodyContent)
-	if err != nil {
-		return nil, err
-	}
-	reader := bytes.NewReader(requestBody)
-
-	ratelimitData, err := c.post(ctx, requestURL, nil, reader)
+	ratelimitData, err := c.post(ctx, requestURL, nil, bodyContent)
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +435,7 @@ func (c *ConfluenceClient) makeRequest(
 	url *url.URL,
 	target interface{},
 	method string,
-	requestBody io.Reader,
+	requestBody interface{},
 ) (*v2.RateLimitDescription, error) {
 	logger := ctxzap.Extract(ctx)
 	logger.Debug(
@@ -448,24 +443,31 @@ func (c *ConfluenceClient) makeRequest(
 		zap.String("url", url.String()),
 		zap.String("method", method),
 	)
-	request, err := http.NewRequestWithContext(
-		ctx,
-		method,
-		url.String(),
-		requestBody,
-	)
-	if err != nil {
-		return nil, err
+	reqOptions := []uhttp.RequestOption{
+		uhttp.WithContentTypeJSONHeader(),
+		uhttp.WithAcceptJSONHeader(),
+	}
+	if requestBody != nil {
+		reqOptions = append(reqOptions, uhttp.WithJSONBody(requestBody))
 	}
 
 	// Auth token has priority.
 	if c.accessToken != "" {
-		request.Header.Set(
-			"Authorization",
-			fmt.Sprintf("Bearer %s", c.accessToken),
-		)
+		reqOptions = append(reqOptions, uhttp.WithBearerToken(c.accessToken))
 	} else {
-		request.SetBasicAuth(c.username, c.password)
+		reqOptions = append(reqOptions,
+			uhttp.WithHeader("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(c.username+":"+c.password)))),
+		)
+	}
+
+	request, err := c.wrapper.NewRequest(
+		ctx,
+		method,
+		url,
+		reqOptions...,
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	ratelimitData := v2.RateLimitDescription{}
@@ -479,11 +481,10 @@ func (c *ConfluenceClient) makeRequest(
 		doOptions = append(doOptions, uhttp.WithJSONResponse(target))
 	}
 
-	// This must be explicitly set for the JSON-RPC server to not error.
-	request.Header.Set("Content-Type", "application/json")
-
 	response, err := c.wrapper.Do(request, doOptions...)
-
+	if response != nil && response.Body != nil {
+		defer response.Body.Close()
+	}
 	if err == nil {
 		return &ratelimitData, nil
 	}
@@ -491,7 +492,6 @@ func (c *ConfluenceClient) makeRequest(
 	if response == nil {
 		return nil, err
 	}
-	defer response.Body.Close()
 
 	// If we get ratelimit data back (e.g. the "Retry-After" header) or a
 	// "ratelimit-like" status code, then return a recoverable gRPC code.
@@ -524,7 +524,7 @@ func (c *ConfluenceClient) post(
 	ctx context.Context,
 	url *url.URL,
 	target interface{},
-	body io.Reader,
+	body interface{},
 ) (*v2.RateLimitDescription, error) {
 	return c.makeRequest(ctx, url, target, http.MethodPost, body)
 }

--- a/pkg/connector/client/confluence.go
+++ b/pkg/connector/client/confluence.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"slices"
@@ -43,21 +42,6 @@ type ConfluenceSpaceEntitlement struct {
 	DisplayName string
 	Key         string
 	Name        string
-}
-
-type RequestError struct {
-	Status int
-	URL    *url.URL
-	Body   string
-}
-
-func (r *RequestError) Error() string {
-	return fmt.Sprintf(
-		"confluence-datacenter-connector: request error. Status: %d, Url: %s, Body: %s",
-		r.Status,
-		r.URL,
-		r.Body,
-	)
 }
 
 type ConfluenceClient struct {
@@ -499,17 +483,7 @@ func (c *ConfluenceClient) makeRequest(
 		return &ratelimitData, status.Error(codes.Unavailable, response.Status)
 	}
 
-	// If it's some other error, it is unrecoverable.
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	return nil, &RequestError{
-		URL:    url,
-		Status: response.StatusCode,
-		Body:   string(responseBody),
-	}
+	return nil, err
 }
 
 func (c *ConfluenceClient) get(

--- a/pkg/connector/spaces.go
+++ b/pkg/connector/spaces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/conductorone/baton-confluence-datacenter/pkg/connector/client"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -16,9 +15,7 @@ import (
 )
 
 type spaceBuilder struct {
-	client                client.ConfluenceClient
-	SpacePermissionsCache map[string][]client.ConfluenceSpacePermission
-	SpacePermissionsMutex sync.RWMutex
+	client client.ConfluenceClient
 }
 
 func (o *spaceBuilder) ResourceType(_ context.Context) *v2.ResourceType {
@@ -68,14 +65,16 @@ func (o *spaceBuilder) Entitlements(
 	var entitlements []*v2.Entitlement
 	spaceKey := resource.Id.Resource
 
-	err := o.EnsureCacheData(ctx, spaceKey)
+	permissionsList, rlData, err := o.client.GetSpacePermissions(
+		ctx,
+		spaceKey,
+	)
+	outputAnnotations := WithRateLimitAnnotations(rlData)
 	if err != nil {
-		return nil, "", nil, err
+		return nil, "", outputAnnotations, err
 	}
 
-	o.SpacePermissionsMutex.RLock()
-	defer o.SpacePermissionsMutex.RUnlock()
-	for _, permission := range o.SpacePermissionsCache[spaceKey] {
+	for _, permission := range permissionsList {
 		operation := permission.Operation
 
 		newEntitlement := entitlement.NewPermissionEntitlement(
@@ -102,12 +101,12 @@ func (o *spaceBuilder) Entitlements(
 		entitlements = append(entitlements, newEntitlement)
 	}
 
-	return entitlements, "", nil, nil
+	return entitlements, "", outputAnnotations, nil
 }
 
 // Grants the grants for a given space are the permissions.
 func (o *spaceBuilder) Grants(
-	_ context.Context,
+	ctx context.Context,
 	resource *v2.Resource,
 	_ *pagination.Token,
 ) (
@@ -116,16 +115,19 @@ func (o *spaceBuilder) Grants(
 	annotations.Annotations,
 	error,
 ) {
-	o.SpacePermissionsMutex.RLock()
-	defer o.SpacePermissionsMutex.RUnlock()
 
 	spaceKey := resource.Id.Resource
-	if len(o.SpacePermissionsCache[spaceKey]) == 0 {
-		return nil, "", nil, fmt.Errorf("no data of space permissions found. Space permissions cache is empty")
+	permissionsList, rlData, err := o.client.GetSpacePermissions(
+		ctx,
+		spaceKey,
+	)
+	outputAnnotations := WithRateLimitAnnotations(rlData)
+	if err != nil {
+		return nil, "", outputAnnotations, err
 	}
 
 	var grants []*v2.Grant
-	for _, permission := range o.SpacePermissionsCache[spaceKey] {
+	for _, permission := range permissionsList {
 		if permission.SpaceKey != resource.Id.Resource {
 			continue
 		}
@@ -156,7 +158,7 @@ func (o *spaceBuilder) Grants(
 		grants = append(grants, newGrant)
 	}
 
-	return grants, "", nil, nil
+	return grants, "", outputAnnotations, nil
 }
 
 func (o *spaceBuilder) Grant(
@@ -164,8 +166,6 @@ func (o *spaceBuilder) Grant(
 	principal *v2.Resource,
 	entitlement *v2.Entitlement,
 ) (annotations.Annotations, error) {
-	o.SpacePermissionsMutex.RLock()
-	defer o.SpacePermissionsMutex.RUnlock()
 
 	entitlementSegments := strings.Split(entitlement.Id, ":")
 	if len(entitlementSegments) == 0 {
@@ -182,9 +182,13 @@ func (o *spaceBuilder) Grant(
 		return nil, err
 	}
 
-	err = o.EnsureCacheData(ctx, spaceKey)
+	permissionsList, rlData, err := o.client.GetSpacePermissions(
+		ctx,
+		spaceKey,
+	)
+	outputAnnotations := WithRateLimitAnnotations(rlData)
 	if err != nil {
-		return nil, err
+		return outputAnnotations, err
 	}
 
 	var userKey, groupName string
@@ -195,7 +199,7 @@ func (o *spaceBuilder) Grant(
 	}
 
 	var currentOperations []client.PermissionOperation
-	for _, spacePermission := range o.SpacePermissionsCache[spaceKey] {
+	for _, spacePermission := range permissionsList {
 		if (userKey != "" && spacePermission.Subject.UserKey == userKey) || (groupName != "" && spacePermission.Subject.Name == groupName) {
 			currentOperations = append(currentOperations, spacePermission.Operation)
 		}
@@ -219,7 +223,7 @@ func (o *spaceBuilder) Grant(
 		return nil, err
 	}
 
-	outputAnnotations := WithRateLimitAnnotations(ratelimitData)
+	outputAnnotations = WithRateLimitAnnotations(ratelimitData)
 	return outputAnnotations, err
 }
 
@@ -253,9 +257,13 @@ func (o *spaceBuilder) Revoke(
 		return nil, err
 	}
 
-	err = o.EnsureCacheData(ctx, spaceKey)
+	permissionsList, rlData, err := o.client.GetSpacePermissions(
+		ctx,
+		spaceKey,
+	)
+	outputAnnotations := WithRateLimitAnnotations(rlData)
 	if err != nil {
-		return nil, err
+		return outputAnnotations, err
 	}
 
 	var userKey, groupName string
@@ -266,7 +274,7 @@ func (o *spaceBuilder) Revoke(
 	}
 
 	var currentOperations []client.PermissionOperation
-	for _, spacePermission := range o.SpacePermissionsCache[spaceKey] {
+	for _, spacePermission := range permissionsList {
 		if (userKey != "" && spacePermission.Subject.UserKey == userKey) || (groupName != "" && spacePermission.Subject.Name == groupName) {
 			if spacePermission.Operation.OperationKey == operationData[0] && spacePermission.Operation.TargetType == operationData[1] {
 				continue
@@ -286,32 +294,13 @@ func (o *spaceBuilder) Revoke(
 		return nil, err
 	}
 
-	outputAnnotations := WithRateLimitAnnotations(ratelimitData)
+	outputAnnotations = WithRateLimitAnnotations(ratelimitData)
 	return outputAnnotations, nil
-}
-
-func (o *spaceBuilder) EnsureCacheData(ctx context.Context, spaceKey string) error {
-	o.SpacePermissionsMutex.Lock()
-	defer o.SpacePermissionsMutex.Unlock()
-
-	if len(o.SpacePermissionsCache[spaceKey]) == 0 {
-		permissionsList, _, err := o.client.GetSpacePermissions(
-			ctx,
-			spaceKey,
-		)
-		if err != nil {
-			return err
-		}
-
-		o.SpacePermissionsCache[spaceKey] = permissionsList
-	}
-	return nil
 }
 
 func newSpaceBuilder(c client.ConfluenceClient) *spaceBuilder {
 	return &spaceBuilder{
-		client:                c,
-		SpacePermissionsCache: make(map[string][]client.ConfluenceSpacePermission),
+		client: c,
 	}
 }
 

--- a/pkg/connector/spaces.go
+++ b/pkg/connector/spaces.go
@@ -115,7 +115,6 @@ func (o *spaceBuilder) Grants(
 	annotations.Annotations,
 	error,
 ) {
-
 	spaceKey := resource.Id.Resource
 	permissionsList, rlData, err := o.client.GetSpacePermissions(
 		ctx,
@@ -166,7 +165,6 @@ func (o *spaceBuilder) Grant(
 	principal *v2.Resource,
 	entitlement *v2.Entitlement,
 ) (annotations.Annotations, error) {
-
 	entitlementSegments := strings.Split(entitlement.Id, ":")
 	if len(entitlementSegments) == 0 {
 		return nil, fmt.Errorf("wrong format on the entitlement id: %s", entitlement.Id)


### PR DESCRIPTION
Use uhttp to make requests. Don't fail sync if fetching grants/entitlements for a resource causes a 404. Don't cache space permissions forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined HTTP communication with simplified error management and support for more flexible data inputs.
	- Simplified space permission retrieval by eliminating local caching for a more direct, up-to-date access control view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->