### PR TITLE
Don't escape path parameters.

### DIFF
--- a/pkg/connector/client/confluence.go
+++ b/pkg/connector/client/confluence.go
@@ -523,11 +523,10 @@ func (c *ConfluenceClient) delete(
 
 func (c *ConfluenceClient) genURLNonPaginated(
 	path string,
-	pathParameters ...any,
+	pathParameters ...string,
 ) (*url.URL, error) {
 	for _, param := range pathParameters {
-		escaped := url.PathEscape(param.(string))
-		path = strings.Replace(path, "%s", escaped, 1)
+		path = strings.Replace(path, "%s", param, 1)
 	}
 	parsed, err := url.Parse(path)
 	if err != nil {
@@ -540,11 +539,10 @@ func (c *ConfluenceClient) genURLNonPaginated(
 func (c *ConfluenceClient) genURL(
 	pageToken string,
 	path string,
-	pathParameters ...any,
+	pathParameters ...string,
 ) (*url.URL, error) {
 	for _, param := range pathParameters {
-		escaped := url.PathEscape(param.(string))
-		path = strings.Replace(path, "%s", escaped, 1)
+		path = strings.Replace(path, "%s", param, 1)
 	}
 	parsed, err := url.Parse(path)
 	if err != nil {


### PR DESCRIPTION
Confluence Data Center has a bug where if you send url encoded slashes, it will return 400 bad request. This hasn't been fixed in at least 5 years: https://community.developer.atlassian.com/t/confluence-rest-api-and-group-name-with/31968/15

It turns out there is no way to list groups with a slash or list who is a member of those groups.

So instead of failing a sync due to a 400, we get a 404 and sync everything but groups that the API can't process.
