### PR TITLE
fix: mark access-token and password as isSecret in config_schema

### DIFF
--- a/cmd/baton-confluence-datacenter/main.go
+++ b/cmd/baton-confluence-datacenter/main.go
@@ -26,9 +26,9 @@ const (
 )
 
 var (
-	accessTokenField    = field.StringField(accessToken, field.WithDescription("The personal access token for your Confluence Data Center account."))
+	accessTokenField    = field.StringField(accessToken, field.WithDescription("The personal access token for your Confluence Data Center account."), field.WithIsSecret(true))
 	hostnameField       = field.StringField(hostname, field.WithRequired(true), field.WithDescription("The hostname (URL) for your Confluence Data Center."))
-	passwordField       = field.StringField(password, field.WithDescription("The password for your Confluence Data Center account."))
+	passwordField       = field.StringField(password, field.WithDescription("The password for your Confluence Data Center account."), field.WithIsSecret(true))
 	usernameField       = field.StringField(username, field.WithDescription("The username for your Confluence Data Center account."))
 	configurationFields = []field.SchemaField{accessTokenField, hostnameField, passwordField, usernameField}
 	fieldRelationships  = []field.SchemaFieldRelationship{


### PR DESCRIPTION
The `access-token` (personal access token) and `password` config fields are Confluence Data Center API credentials but were defined as plain `field.StringField` with no `field.WithIsSecret(true)`, so neither was marked secret. This adds `WithIsSecret(true)` to both. The `username` and `hostname` fields are not credentials and are correctly left unmarked.

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

_Built with stargate._
